### PR TITLE
build(dockerfile): add cargo-leptos

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -8,32 +8,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Set up QEMU for multi-arch builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push multi-arch image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           builder: ${{ steps.docker_buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64 #,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: evilrobotindustries/wasm:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
 
 

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,6 +1,8 @@
-# Based on https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-name: Publish Docker image
-on: [push]
+name: release
+on:
+  push:
+    branches:
+      - "main"
 
 jobs:
   push_to_registry:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,44 @@
-FROM rust:slim
+FROM rust:1.86-slim
 
-ENV WASM_BINDGEN_CLI_VERSION=0.2.81
+ENV WASM_BINDGEN_CLI_VERSION=0.2.100
 ENV WASM_BINDGEN_CLI_VERSION=${WASM_BINDGEN_CLI_VERSION}
 
-ENV STATIC_WEB_SERVER_VERSION=2.9.0
+ENV STATIC_WEB_SERVER_VERSION=2.36.1
 ENV STATIC_WEB_SERVER_VERSION=${STATIC_WEB_SERVER_VERSION}
 
+ARG TARGETARCH
+ENV ARCH=$TARGETARCH
+
 # Install tools
-RUN apt-get update; \
-    apt-get install -y --no-install-recommends libssl-dev pkg-config wget; \
+RUN set -eux; \
+    apt-get update && \
+    apt-get install -y --no-install-recommends build-essential libssl-dev pkg-config wget && \
     # Install wasm-bindgen
-    cargo install wasm-bindgen-cli --version ${WASM_BINDGEN_CLI_VERSION}; \
-    rustup target add wasm32-unknown-unknown; \
+    cargo install wasm-bindgen-cli --version ${WASM_BINDGEN_CLI_VERSION} && \
+    rustup target add wasm32-unknown-unknown && \
     # Install trunk
-    cargo install trunk; \
+    cargo install trunk && \
+    # Install cargo-leptos
+    cargo install cargo-leptos --locked && \
     # Clean up cargo registry
-    rm /usr/local/cargo/registry/cache/* -rf; \
-    rm /usr/local/cargo/registry/index/* -rf; \
-    rm /usr/local/cargo/registry/src/* -rf; \
-    # Install static-web-server
-	wget --quiet -O /tmp/static-web-server.tar.gz "https://github.com/joseluisq/static-web-server/releases/download/v$STATIC_WEB_SERVER_VERSION/static-web-server-v$STATIC_WEB_SERVER_VERSION-x86_64-unknown-linux-gnu.tar.gz"; \
-    tar xzvf /tmp/static-web-server.tar.gz; \
-    cp static-web-server-v${STATIC_WEB_SERVER_VERSION}-x86_64-unknown-linux-gnu/static-web-server /usr/local/bin/; \
-	rm -rf /tmp/static-web-server.tar.gz static-web-server-v${STATIC_WEB_SERVER_VERSION}-x86_64-unknown-linux-gnu; \
-	chmod +x /usr/local/bin/static-web-server; \
-    # Clean up
-    apt-get remove -y --auto-remove libssl-dev pkg-config wget ; \
-    rm -rf /var/lib/apt/lists/*;
+    rm -rf /usr/local/cargo/downloads /usr/local/cargo/registry/cache/* /usr/local/cargo/registry/index/* /usr/local/cargo/registry/src/* /usr/local/cargo/tmp && \
+    # Install static-web-server \
+    case ${TARGETARCH} in \
+        "amd64")  RUST_ARCH="x86_64"  ;; \
+        "arm64")  RUST_ARCH="aarch64" ;; \
+        *)        RUST_ARCH=${TARGETARCH} ;; \
+    esac && \
+	wget --quiet -O /tmp/static-web-server.tar.gz "https://github.com/joseluisq/static-web-server/releases/download/v$STATIC_WEB_SERVER_VERSION/static-web-server-v$STATIC_WEB_SERVER_VERSION-$RUST_ARCH-unknown-linux-gnu.tar.gz" && \
+    tar xzvf /tmp/static-web-server.tar.gz && \
+    cp static-web-server-v${STATIC_WEB_SERVER_VERSION}-${RUST_ARCH}-unknown-linux-gnu/static-web-server /usr/local/bin/ && \
+	rm -rf /tmp/static-web-server.tar.gz static-web-server-v${STATIC_WEB_SERVER_VERSION}-${RUST_ARCH}-unknown-linux-gnu && \
+	chmod +x /usr/local/bin/static-web-server && \
+    # Clean up \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    apt-get remove -y --auto-remove build-essential libssl-dev pkg-config wget && \
+    rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man /usr/local/doc /usr/lib/llvm-11 /tmp/* /var/tmp/*
+
 EXPOSE 80
 
 # Metadata
@@ -34,5 +46,5 @@ LABEL org.opencontainers.image.vendor="Evil Robot Industries" \
     org.opencontainers.image.url="https://github.com/evilrobotindustries/wasm-docker" \
     org.opencontainers.image.title="Rust WebAssembly Toolchain" \
     org.opencontainers.image.description="A toolchain for Rust WebAssembly development." \
-    org.opencontainers.image.version="0.1" \
+    org.opencontainers.image.version="0.2" \
     org.opencontainers.image.documentation="https://github.com/evilrobotindustries/wasm-docker"

--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@ A Dockerised toolchain for Rust WebAssembly development/deployment, based on the
 
 The image also includes the following tools:
 
-## [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen)
-"Facilitating high-level interactions between Wasm modules and JavaScript", used to generate the final wasm image along with .js bootstrap code.
+## [leptos](https://github.com/leptos-rs/cargo-leptos)
+Build tool for [Leptos](https://github.com/leptos-rs/leptos), for building fast web applications with Rust.
 
-    # Development/debug
-    cargo build --target wasm32-unknown-unknown && wasm-bindgen --debug --no-typescript --out-dir www/pkg --target web ./target/wasm32-unknown-unknown/debug/*.wasm
-    # Release/deployment
-    cargo build --release --target wasm32-unknown-unknown && wasm-bindgen --browser --no-typescript --out-dir www/pkg --target web ./target/wasm32-unknown-unknown/release/*.wasm
+    cargo leptos watch
+    cargo leptos build --release
 
 ## [static-web-server](https://github.com/joseluisq/static-web-server)
 A Rust-based static web server, for hosting static content over HTTPS. The following example starts the server using the www directory as the root and turns on tracing for debugging: 
@@ -22,3 +20,11 @@ A certificate can then be generated on the development host using [mkcert](https
 
 ## [trunk](https://github.com/thedodd/trunk)
 "Trunk is a WASM web application bundler for Rust", included for producing trunk builds when using trunk during development.
+
+## [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen)
+"Facilitating high-level interactions between Wasm modules and JavaScript", used to generate the final wasm image along with .js bootstrap code.
+
+    # Development/debug
+    cargo build --target wasm32-unknown-unknown && wasm-bindgen --debug --no-typescript --out-dir www/pkg --target web ./target/wasm32-unknown-unknown/debug/*.wasm
+    # Release/deployment
+    cargo build --release --target wasm32-unknown-unknown && wasm-bindgen --browser --no-typescript --out-dir www/pkg --target web ./target/wasm32-unknown-unknown/release/*.wasm


### PR DESCRIPTION
Adds `cargo-leptos` to the Docker image, along with updates to the readme and publish workflow.