### PR TITLE
feat: add build-leptos script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,26 @@
+name: check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,26 @@
+name: check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 # wasm-docker
 A Dockerised toolchain for Rust WebAssembly development/deployment, based on the [rust:slim](https://hub.docker.com/_/rust) image.
 
-The image also includes the following tools:
+## Tools
+The image includes the following tools:
 
-## [leptos](https://github.com/leptos-rs/cargo-leptos)
-Build tool for [Leptos](https://github.com/leptos-rs/leptos), for building fast web applications with Rust.
+### [Cargo B(inary)Install](https://github.com/cargo-bins/cargo-binstall)
+Binstall provides a low-complexity mechanism for installing Rust binaries as an alternative to building from source (via cargo install) or manually downloading packages.
 
-    cargo leptos watch
-    cargo leptos build --release
+### build-leptos
+Build script for [Leptos](https://github.com/leptos-rs/leptos) projects, for building fast web applications with Rust.
 
-## [static-web-server](https://github.com/joseluisq/static-web-server)
-A Rust-based static web server, for hosting static content over HTTPS. The following example starts the server using the www directory as the root and turns on tracing for debugging: 
+#### Usage
+    build-leptos [post-build-command]
+
+> Note: [`build-leptos`](./scripts/build-leptos.sh) installs [`cargo-leptos`](https://github.com/leptos-rs/cargo-leptos) on-demand via `cargo binstall`.
+
+### [static-web-server](https://github.com/joseluisq/static-web-server)
+A Rust-based static web server, for hosting static content over HTTPS.
+
+The following example starts the server using the www directory as the root and turns on tracing for debugging:
 
     static-web-server --root ./www -g trace
 
@@ -18,11 +26,22 @@ A certificate can then be generated on the development host using [mkcert](https
 
     static-web-server --root ./www -g trace --http2 true --http2-tls-cert /localhost.pem --http2-tls-key /localhost-key.pem
 
-## [trunk](https://github.com/thedodd/trunk)
+### [trunk](https://github.com/thedodd/trunk)
 "Trunk is a WASM web application bundler for Rust", included for producing trunk builds when using trunk during development.
 
-## [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen)
+Run `trunk` to see usage information.
+
+## Additional Tools
+The following additional tools are not included, but can easily be installed.
+
+### [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen)
 "Facilitating high-level interactions between Wasm modules and JavaScript", used to generate the final wasm image along with .js bootstrap code.
+
+#### Installation
+
+    cargo binstall wasm-bindgen-cli --no-confirm
+
+#### Usage
 
     # Development/debug
     cargo build --target wasm32-unknown-unknown && wasm-bindgen --debug --no-typescript --out-dir www/pkg --target web ./target/wasm32-unknown-unknown/debug/*.wasm

--- a/scripts/build-leptos.sh
+++ b/scripts/build-leptos.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+echo "🦀 Building Leptos project with auto-detected dependencies..."
+
+# Install project-specific tools with matching versions
+echo "📦 Installing cargo-leptos..."
+cargo binstall cargo-leptos --no-confirm
+
+WASM_BINDGEN_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "wasm-bindgen") | .version')
+echo "📦 Installing wasm-bindgen-cli version $WASM_BINDGEN_VERSION..."
+cargo binstall wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION" --no-confirm
+
+# Build the project
+echo "🔨 Building Leptos project..."
+cargo leptos build --release
+
+# Run any additional commands passed as arguments
+if [ $# -gt 0 ]; then
+    echo "🔧 Running post-build command: $@"
+    "$@"
+fi
+
+echo "✅ Build complete!"


### PR DESCRIPTION
Adds `build-leptos.sh` to Dockerfile for builds of leptos projects via `build-leptos`, so that `cargo-leptos` and `wasm-bindgen-cli` are installed on demand (via `cargo-binstall`) based on required versions specific to a project.

Usage: `build-leptos [post-build-command]`